### PR TITLE
Swedish translations + test.

### DIFF
--- a/lib/lang/sv.js
+++ b/lib/lang/sv.js
@@ -1,0 +1,160 @@
+function join_with_shared_prefix(a, b, joiner) {
+  var m = a,
+      i = 0,
+      j;
+
+  while(i !== m.length &&
+        i !== b.length &&
+        m.charCodeAt(i) === b.charCodeAt(i))
+    ++i;
+
+  while(i && m.charCodeAt(i - 1) !== 32)
+    --i;
+
+  return a + joiner + b.slice(i);
+}
+
+function strip_prefix(period) {
+  return period.slice(0, 12) === "över natten" ? period.slice(5) :
+         period.slice(0, 6)  === "under "      ? period.slice(6) :
+                                                 period;
+}
+
+function grammar(str) {
+  return str.replace(/på /gi, "under ")
+            .replace(/(ån|is|ns|rs|re|ör|ön)(dag)/gi, "$1dagen");
+}
+
+module.exports = require("../template")({
+  "clear": "klart",
+  "no-precipitation": "ingen mätbar nederbörd",
+  "mixed-precipitation": "blandat nederbörd",
+  "possible-very-light-precipitation": "möjligtvis mycket lätt nederbörd",
+  "very-light-precipitation": "mycket lätt nederbörd",
+  "possible-light-precipitation": "möjligtvis lätt nederbörd",
+  "light-precipitation": "lätt nederbörd",
+  "medium-precipitation": "nederbörd",
+  "heavy-precipitation": "kraftigt nederbörd",
+  "possible-very-light-rain": "möjligtvis lite duggregn",
+  "very-light-rain": "duggregn",
+  "possible-light-rain": "möjligtvis lätta regnskurar",
+  "light-rain": "regnskurar",
+  "medium-rain": "regn",
+  "heavy-rain": "skyfall",
+  "possible-very-light-sleet": "möjligtvis mycket lätt snöblandat regn",
+  "very-light-sleet": "mycket lätt snöblandat regn",
+  "possible-light-sleet": "möjligtvis lätt snöblandat regn",
+  "light-sleet": "lätt snöblandat regn",
+  "medium-sleet": "snöblandat regn",
+  "heavy-sleet": "tungt snöblandat regn",
+  "possible-very-light-snow": "möjligtvis lätt snöby",
+  "very-light-snow": "lätt snöby",
+  "possible-light-snow": "möjligtvis lätt snöfall",
+  "light-snow": "lätt snöfall",
+  "medium-snow": "snöby",
+  "heavy-snow": "rikligt med snö",
+  "light-wind": "svag vind",
+  "medium-wind": "hård vind",
+  "heavy-wind": "storm",
+  "low-humidity": "torka",
+  "high-humidity": "fuktigt",
+  "fog": "dimma",
+  "light-clouds": "lätt molnighet",
+  "medium-clouds": "molnigt",
+  "heavy-clouds": "mulet",
+  "today-morning": "under morgonen",
+  "later-today-morning": "senare under morgonen",
+  "today-afternoon": "på eftermiddagen",
+  "later-today-afternoon": "senare under eftermiddagen",
+  "today-evening": "under aftonen",
+  "later-today-evening": "senare under aftonen",
+  "today-night": "ikväll",
+  "later-today-night": "senare ikväll",
+  "tomorrow-morning": "imorgon bitti",
+  "tomorrow-afternoon": "imorgon eftermiddag",
+  "tomorrow-evening": "imorgon afton",
+  "tomorrow-night": "imorgon natt",
+  "morning": "på morgonen",
+  "afternoon": "under eftermiddagen",
+  "evening": "under aftonen",
+  "night": "över natten",
+  "today": "idag",
+  "tomorrow": "imorgon",
+  "sunday": "på söndag",
+  "monday": "på måndag",
+  "tuesday": "på tisdag",
+  "wednesday": "på onsdag",
+  "thursday": "på torsdag",
+  "friday": "på fredag",
+  "saturday": "på lördag",
+  "minutes": "$1 min.",
+  "fahrenheit": "$1\u00B0F",
+  "celsius": "$1\u00B0C",
+  "inches": "$1 in.",
+  "centimeters": "$1 cm.",
+  "less-than": "under $1",
+  "and": function(a, b) {
+    return join_with_shared_prefix(
+      a,
+      b,
+      a.indexOf(",") !== -1 ? " och " : " och "
+    );
+  },
+  "through": function(a, b) {
+    return join_with_shared_prefix(a, b, " fram till ");
+  },
+  "with": "$1, med $2",
+  "range": "$1\u2013$2",
+  "parenthetical": "$1 ($2)",
+  "for-hour": "$1 under närmaste timme",
+  "starting-in": "$1 som startar om $2",
+  "stopping-in": "$1 som avtar om $2",
+  "starting-then-stopping-later": "$1 som startar om $2, avtar $3 senare",
+  "stopping-then-starting-later": "$1 avtar om $2, startar igen $3 senare",
+  "for-day": "$1 under dagen",
+  "starting": "$1 som startar $2",
+  "until": function(condition, period) {
+    return condition + " fram till " + strip_prefix(period);
+  },
+  "until-starting-again": function(condition, a, b) {
+    return condition + " fram till " + strip_prefix(a) +
+           ", som startar igen " + b;
+  },
+  "starting-continuing-until": function(condition, a, b) {
+    return condition + " som startar " + a + ", fortsätter fram till " +
+           strip_prefix(b);
+  },
+  "during": "$1 $2",
+  "for-week": "$1 under veckan",
+  "over-weekend": "$1 över helgen",
+  "temperatures-peaking": function(a, b) {
+    return "temperaturer upp till " + a + " " + grammar(b);
+  },
+  "temperatures-rising": function(a, b) {
+    return "temperaturer som stiger till " + a + " " + grammar(b);
+  },
+  "temperatures-valleying": function(a, b) {
+    return "temperaturer som stannar på " + a + " " + grammar(b);
+  },
+  "temperatures-falling": function(a, b) {
+    return "temperaturer som sjunker till " + a + " " + grammar(b);
+  },
+  /* Capitalize the first character in the word.
+   * We never titleize nor camelcase words in an sentence in Swedish. */
+  "title": function(str) {
+    /* Capitalize. */
+    str = str.charAt(0).toUpperCase() + str.slice(1);
+    return str;
+  },
+  /* Capitalize the first word of the sentence and end with a period. */
+  "sentence": function(str) {
+    /* Capitalize. */
+    str = str.charAt(0).toUpperCase() + str.slice(1);
+
+    /* Add a period if there isn't already one. */
+    if(str.charAt(str.length - 1) !== ".")
+      str += ".";
+
+    return str;
+  }
+});

--- a/test_cases/sv.json
+++ b/test_cases/sv.json
@@ -1,0 +1,237 @@
+{
+  "Klart":
+    ["title", "clear"],
+
+  "Möjligtvis mycket lätt nederbörd":
+    ["title", "possible-very-light-precipitation"],
+
+  "Mycket lätt nederbörd":
+    ["title", "very-light-precipitation"],
+
+  "Möjligtvis lätt nederbörd":
+    ["title", "possible-light-precipitation"],
+
+  "Lätt nederbörd":
+    ["title", "light-precipitation"],
+
+  "Nederbörd":
+    ["title", "medium-precipitation"],
+
+  "Kraftigt nederbörd":
+    ["title", "heavy-precipitation"],
+
+  "Möjligtvis lite duggregn":
+    ["title", "possible-very-light-rain"],
+
+  "Duggregn":
+    ["title", "very-light-rain"],
+
+  "Möjligtvis lätta regnskurar":
+    ["title", "possible-light-rain"],
+
+  "Regnskurar":
+    ["title", "light-rain"],
+
+  "Regn":
+    ["title", "medium-rain"],
+
+  "Skyfall":
+    ["title", "heavy-rain"],
+
+  "Möjligtvis mycket lätt snöblandat regn":
+    ["title", "possible-very-light-sleet"],
+
+  "Mycket lätt snöblandat regn":
+    ["title", "very-light-sleet"],
+
+  "Möjligtvis lätt snöblandat regn":
+    ["title", "possible-light-sleet"],
+
+  "Lätt snöblandat regn":
+    ["title", "light-sleet"],
+
+  "Snöblandat regn":
+    ["title", "medium-sleet"],
+
+  "Tungt snöblandat regn":
+    ["title", "heavy-sleet"],
+
+  "Möjligtvis lätt snöby":
+    ["title", "possible-very-light-snow"],
+
+  "Lätt snöby":
+    ["title", "very-light-snow"],
+
+  "Möjligtvis lätt snöfall":
+    ["title", "possible-light-snow"],
+
+  "Lätt snöfall":
+    ["title", "light-snow"],
+
+  "Snöby":
+    ["title", "medium-snow"],
+
+  "Rikligt med snö":
+    ["title", "heavy-snow"],
+
+  "Hård vind":
+    ["title", "medium-wind"],
+
+  "Storm":
+    ["title", "heavy-wind"],
+
+  "Dimma":
+    ["title", "fog"],
+
+  "Molnigt":
+    ["title", "medium-clouds"],
+
+  "Mulet":
+    ["title", "heavy-clouds"],
+
+  "Torka och svag vind":
+    ["title", ["and", "low-humidity", "light-wind"]],
+
+  "Duggregn och storm":
+    ["title", ["and", "very-light-rain", "heavy-wind"]],
+
+  "Fuktigt och lätt molnighet":
+    ["title", ["and", "high-humidity", "light-clouds"]],
+
+  "Klart under närmaste timme.":
+    ["sentence", ["for-hour", "clear"]],
+
+  "Lätt snöby som startar om 35 min.":
+    ["sentence", ["starting-in", "very-light-snow", ["minutes", 35]]],
+
+  "Regnskurar som avtar om 15 min.":
+    ["sentence", ["stopping-in", "light-rain", ["minutes", 15]]],
+
+  "Tungt snöblandat regn som startar om 20 min., avtar 30 min. senare.":
+    ["sentence",
+      ["starting-then-stopping-later",
+        "heavy-sleet",
+        ["minutes", 20],
+        ["minutes", 30]]],
+
+  "Regn avtar om 25 min., startar igen 8 min. senare.":
+    ["sentence",
+      ["stopping-then-starting-later",
+        "medium-rain",
+        ["minutes", 25],
+        ["minutes", 8]]],
+
+  "Molnigt under dagen.":
+    ["sentence", ["for-day", "medium-clouds"]],
+
+  "Mycket lätt snöblandat regn som startar på morgonen.":
+    ["sentence", ["starting", "very-light-sleet", "morning"]],
+
+  "Hård vind fram till ikväll.":
+    ["sentence", ["until", "medium-wind", "today-night"]],
+
+  "Kraftigt nederbörd fram till eftermiddagen.":
+    ["sentence", ["until", "heavy-precipitation", "afternoon"]],
+
+  "Svag vind under eftermiddagen.":
+    ["sentence", ["during", "light-wind", "afternoon"]],
+
+  "Snöby senare under aftonen och imorgon bitti.":
+    ["sentence", ["during",
+      "medium-snow",
+      ["and", "later-today-evening", "tomorrow-morning"]]],
+
+  "Skyfall fram till senare under morgonen, som startar igen under aftonen.":
+    ["sentence", ["until-starting-again",
+      "heavy-rain",
+      "later-today-morning",
+      "today-evening"]],
+
+  "Mulet som startar under aftonen, fortsätter fram till natten.":
+    ["sentence", ["starting-continuing-until",
+      "heavy-clouds",
+      "evening",
+      "night"]],
+
+  "Lätt snöblandat regn senare under eftermiddagen och dimma imorgon bitti.":
+    ["sentence", ["and",
+      ["during", "light-sleet", "later-today-afternoon"],
+      ["during", "fog", "tomorrow-morning"]]],
+
+  "Storm som startar under morgonen, fortsätter fram till på eftermiddagen och snöblandat regn imorgon bitti.":
+    ["sentence", ["and",
+      ["starting-continuing-until",
+        "heavy-wind",
+        "today-morning",
+        "today-afternoon"],
+      ["during", "medium-sleet", "tomorrow-morning"]]],
+
+  "Mulet som startar senare ikväll och rikligt med snö imorgon eftermiddag.":
+    ["sentence", ["and",
+      ["starting", "heavy-clouds", "later-today-night"],
+      ["during", "heavy-snow", "tomorrow-afternoon"]]],
+
+  "Torka ikväll och lätt nederbörd som startar imorgon afton, fortsätter fram till imorgon natt.":
+    ["sentence", ["and",
+      ["during", "low-humidity", "today-night"],
+      ["starting-continuing-until",
+        "light-precipitation",
+        "tomorrow-evening",
+        "tomorrow-night"]]],
+
+  "Snöby (5 in.) över natten.":
+    ["sentence", ["during",
+      ["parenthetical", "medium-snow", ["inches", 5]],
+      "night"]],
+
+  "Lätt snöfall (2 cm.) senare under morgonen.":
+    ["sentence", ["during",
+      ["parenthetical", "light-snow", ["centimeters", 2]],
+      "later-today-morning"]],
+
+  "Rikligt med snö (8\u201312 in.) under dagen.":
+    ["sentence", ["for-day",
+      ["parenthetical", "heavy-snow", ["inches", ["range", 8, 12]]]]],
+
+  "Snöby (under 1 cm.) under eftermiddagen.":
+    ["sentence", ["during",
+      ["parenthetical", "medium-snow", ["less-than", ["centimeters", 1]]],
+      "afternoon"]],
+
+  "Ingen mätbar nederbörd under veckan, med temperaturer upp till 85\u00B0F imorgon.":
+    ["sentence", ["with",
+      ["for-week", "no-precipitation"],
+      ["temperatures-peaking",
+        ["fahrenheit", 85],
+        "tomorrow"]]],
+
+  "Blandat nederbörd över helgen, med temperaturer som stiger till 32\u00B0C under torsdagen.":
+    ["sentence", ["with",
+      ["over-weekend", "mixed-precipitation"],
+      ["temperatures-rising",
+        ["celsius", 32],
+        "thursday"]]],
+
+  "Duggregn på måndag, med temperaturer som stannar på 15\u00B0F under fredagen.":
+    ["sentence", ["with",
+      ["during", "very-light-rain", "monday"],
+      ["temperatures-valleying",
+        ["fahrenheit", 15],
+        "friday"]]],
+
+  "Lätt snöfall på tisdag och onsdag, med temperaturer som sjunker till 0\u00B0C under söndagen.":
+    ["sentence", ["with",
+      ["during", "light-snow", ["and", "tuesday", "wednesday"]],
+      ["temperatures-falling",
+        ["celsius", 0],
+        "sunday"]]],
+
+  "Nederbörd idag fram till på lördag, med temperaturer upp till 100\u00B0F under måndagen.":
+    ["sentence", ["with",
+      ["during",
+        "medium-precipitation",
+        ["through", "today", "saturday"]],
+      ["temperatures-peaking",
+        ["fahrenheit", 100],
+        "monday"]]]
+}


### PR DESCRIPTION
Adds also function to correct grammatical accuracy where weekdays e.g. “på söndag” should be transformed to “under söndagen”. Vocabulary ref: [SMHI](http://www.smhi.se/kunskapsbanken/meteorologi/vaderspraket-1.3847).

It would be more accurate if words could be set by a range calculation e.g. 
return "snow" when degree <= 0.0
return "wet-snow" when degree > 0.0 || < 5.0
...
and similar with wind based on Beaufort etc.