### PR TITLE
Add Norwegian Bokmaal translations

### DIFF
--- a/lib/lang/nb.js
+++ b/lib/lang/nb.js
@@ -1,0 +1,160 @@
+function join_with_shared_prefix(a, b, joiner) {
+  var m = a,
+      i = 0,
+      j;
+
+  while(i !== m.length &&
+        i !== b.length &&
+        m.charCodeAt(i) === b.charCodeAt(i))
+    ++i;
+
+  while(i && m.charCodeAt(i - 1) !== 32)
+    --i;
+
+  return a + joiner + b.slice(i);
+}
+
+function strip_prefix(period) {
+  return period.slice(0, 12) === "över natten" ? period.slice(5) :
+         period.slice(0, 6)  === "under "      ? period.slice(6) :
+                                                 period;
+}
+
+function grammar(str) {
+    return str; //str.replace(/på /gi, "under ")
+            //.replace(/(ån|is|ns|rs|re|ör|ön)(dag)/gi, "$1dagen");
+}
+
+module.exports = require("../template")({
+  "clear": "klart",
+  "no-precipitation": "ingen målbar nedbør",
+  "mixed-precipitation": "blandet nedbør",
+  "possible-very-light-precipitation": "sjanse for veldig lett nedbør",
+  "very-light-precipitation": "veldig lett nedbør",
+  "possible-light-precipitation": "sjanse for lett nedbør",
+  "light-precipitation": "lett nedbør",
+  "medium-precipitation": "nedbør",
+  "heavy-precipitation": "kraftig regn",
+  "possible-very-light-rain": "sjanse for lett duskregn",
+  "very-light-rain": "duskregn",
+  "possible-light-rain": "sjanse for lette regnbyger",
+  "light-rain": "regnbyger",
+  "medium-rain": "regn",
+  "heavy-rain": "regnskyll",
+  "possible-very-light-sleet": "sjanse for veldig lett sludd",
+  "very-light-sleet": "veldig lett sludd",
+  "possible-light-sleet": "sjanse for lett sludd",
+  "light-sleet": "lett sludd",
+  "medium-sleet": "sludd",
+  "heavy-sleet": "kraftig sludd",
+  "possible-very-light-snow": "sjanse for vedlig lett snø",
+  "very-light-snow": "veldig lett snø",
+  "possible-light-snow": "sjanse for lett snø",
+  "light-snow": "lett snø",
+  "medium-snow": "snø",
+  "heavy-snow": "rikelig med snø",
+  "light-wind": "lett vind",
+  "medium-wind": "sterk vind",
+  "heavy-wind": "storm",
+  "low-humidity": "tørke",
+  "high-humidity": "fuktig",
+  "fog": "tåke",
+  "light-clouds": "lettskyet",
+  "medium-clouds": "skyet",
+  "heavy-clouds": "overskyet",
+  "today-morning": "i løpet av formiddagen",
+  "later-today-morning": "senere på morgenen",
+  "today-afternoon": "på ettermiddagen",
+  "later-today-afternoon": "senere på ettermiddagen",
+  "today-evening": "i løpet av kvelden",
+  "later-today-evening": "senere på kvelden",
+  "today-night": "i kveld",
+  "later-today-night": "senere i kveld",
+  "tomorrow-morning": "i morgen tidlig",
+  "tomorrow-afternoon": "i morgen ettermiddag",
+  "tomorrow-evening": "i morgen kveld",
+  "tomorrow-night": "i morgen natt",
+  "morning": "om morgenen",
+  "afternoon": "på ettermiddagen",
+  "evening": "om kvelden",
+  "night": "om natten",
+  "today": "i dag",
+  "tomorrow": "i morgen",
+  "sunday": "på søndag",
+  "monday": "på mandag",
+  "tuesday": "på tirsdag",
+  "wednesday": "på onsdag",
+  "thursday": "på torsdag",
+  "friday": "på fredag",
+  "saturday": "på lørdag",
+  "minutes": "$1 min.",
+  "fahrenheit": "$1\u00B0F",
+  "celsius": "$1\u00B0C",
+  "inches": "$1 in.",
+  "centimeters": "$1 cm.",
+  "less-than": "under $1",
+  "and": function(a, b) {
+    return join_with_shared_prefix(
+      a,
+      b,
+      a.indexOf(",") !== -1 ? " og " : " og "
+    );
+  },
+  "through": function(a, b) {
+    return join_with_shared_prefix(a, b, " fram til ");
+  },
+  "with": "$1, med $2",
+  "range": "$1\u2013$2",
+  "parenthetical": "$1 ($2)",
+  "for-hour": "$1 i løpet av de neste timene",
+  "starting-in": "$1 som starter om $2",
+  "stopping-in": "$1 som avtar om $2",
+  "starting-then-stopping-later": "$1 som starter om $2, avtar $3 senere",
+  "stopping-then-starting-later": "$1 avtar om $2, starter igjen $3 senere",
+  "for-day": "$1 i løpet av dagen",
+  "starting": "$1 som starter $2",
+  "until": function(condition, period) {
+      return condition + " fram til " + strip_prefix(period);
+  },
+  "until-starting-again": function(condition, a, b) {
+      return condition + " fram til " + strip_prefix(a) +
+           ", som starter igjen " + b;
+  },
+  "starting-continuing-until": function(condition, a, b) {
+      return condition + " som starter " + a + ", fortsetter fram til " +
+           strip_prefix(b);
+  },
+  "during": "$1 $2",
+  "for-week": "$1 i løpet av uken",
+  "over-weekend": "$1 over helgen",
+  "temperatures-peaking": function(a, b) {
+      return "temperaturer opptil " + a + " " + grammar(b);
+  },
+  "temperatures-rising": function(a, b) {
+      return "temperaturer som stiger til " + a + " " + grammar(b);
+  },
+  "temperatures-valleying": function(a, b) {
+      return "temperaturer som stopper på " + a + " " + grammar(b);
+  },
+  "temperatures-falling": function(a, b) {
+      return "temperaturer som synker til " + a + " " + grammar(b);
+  },
+  /* Capitalize the first character in the word.
+   * We never titleize nor camelcase words in an sentence in Swedish. */
+  "title": function(str) {
+    /* Capitalize. */
+    str = str.charAt(0).toUpperCase() + str.slice(1);
+    return str;
+  },
+  /* Capitalize the first word of the sentence and end with a period. */
+  "sentence": function(str) {
+    /* Capitalize. */
+    str = str.charAt(0).toUpperCase() + str.slice(1);
+
+    /* Add a period if there isn't already one. */
+    if(str.charAt(str.length - 1) !== ".")
+      str += ".";
+
+    return str;
+  }
+});

--- a/test_cases/nb.json
+++ b/test_cases/nb.json
@@ -1,0 +1,237 @@
+{
+  "Klart":
+    ["title", "clear"],
+
+  "Sjanse for veldig lett nedbør":
+    ["title", "possible-very-light-precipitation"],
+
+  "Veldig lett nedbør":
+    ["title", "very-light-precipitation"],
+
+  "Sjanse for lett nedbør":
+    ["title", "possible-light-precipitation"],
+
+  "Lett nedbør":
+    ["title", "light-precipitation"],
+
+  "Nedbør":
+    ["title", "medium-precipitation"],
+
+  "Kraftig regn":
+    ["title", "heavy-precipitation"],
+
+  "Sjanse for lett duskregn":
+    ["title", "possible-very-light-rain"],
+
+  "Duskregn":
+    ["title", "very-light-rain"],
+
+  "Sjanse for lette regnbyger":
+    ["title", "possible-light-rain"],
+
+  "Regnbyger":
+    ["title", "light-rain"],
+
+  "Regn":
+    ["title", "medium-rain"],
+
+  "Regnskyll":
+    ["title", "heavy-rain"],
+
+  "Sjanse for veldig lett sludd":
+    ["title", "possible-very-light-sleet"],
+
+  "Veldig lett sludd":
+    ["title", "very-light-sleet"],
+
+  "Sjanse for lett sludd":
+    ["title", "possible-light-sleet"],
+
+  "Lett sludd":
+    ["title", "light-sleet"],
+
+  "Sludd":
+    ["title", "medium-sleet"],
+
+  "Kraftig sludd":
+    ["title", "heavy-sleet"],
+
+  "Sjanse for vedlig lett snø":
+    ["title", "possible-very-light-snow"],
+
+  "Veldig lett snø":
+    ["title", "very-light-snow"],
+
+  "Sjanse for lett snø":
+    ["title", "possible-light-snow"],
+
+  "Lett snø":
+    ["title", "light-snow"],
+
+  "Snø":
+    ["title", "medium-snow"],
+
+  "Rikelig med snø":
+    ["title", "heavy-snow"],
+
+  "Sterk vind":
+    ["title", "medium-wind"],
+
+  "Storm":
+    ["title", "heavy-wind"],
+
+  "Tåke":
+    ["title", "fog"],
+
+  "Skyet":
+    ["title", "medium-clouds"],
+
+  "Overskyet":
+    ["title", "heavy-clouds"],
+
+  "Tørke og lett vind":
+    ["title", ["and", "low-humidity", "light-wind"]],
+
+  "Duskregn og storm":
+    ["title", ["and", "very-light-rain", "heavy-wind"]],
+
+  "Fuktig og lettskyet":
+    ["title", ["and", "high-humidity", "light-clouds"]],
+
+  "Klart i løpet av de neste timene.":
+    ["sentence", ["for-hour", "clear"]],
+
+  "Veldig lett snø som starter om 35 min.":
+    ["sentence", ["starting-in", "very-light-snow", ["minutes", 35]]],
+
+  "Regnbyger som avtar om 15 min.":
+    ["sentence", ["stopping-in", "light-rain", ["minutes", 15]]],
+
+  "Kraftig sludd som starter om 20 min., avtar 30 min. senere.":
+    ["sentence",
+      ["starting-then-stopping-later",
+        "heavy-sleet",
+        ["minutes", 20],
+        ["minutes", 30]]],
+
+  "Regn avtar om 25 min., starter igjen 8 min. senere.":
+    ["sentence",
+      ["stopping-then-starting-later",
+        "medium-rain",
+        ["minutes", 25],
+        ["minutes", 8]]],
+
+  "Skyet i løpet av dagen.":
+    ["sentence", ["for-day", "medium-clouds"]],
+
+  "Veldig lett sludd som starter om morgenen.":
+    ["sentence", ["starting", "very-light-sleet", "morning"]],
+
+  "Sterk vind fram til i kveld.":
+    ["sentence", ["until", "medium-wind", "today-night"]],
+
+  "Kraftig regn fram til på ettermiddagen.":
+    ["sentence", ["until", "heavy-precipitation", "afternoon"]],
+
+  "Lett vind på ettermiddagen.":
+    ["sentence", ["during", "light-wind", "afternoon"]],
+
+  "Snø senere på kvelden og i morgen tidlig.":
+    ["sentence", ["during",
+      "medium-snow",
+      ["and", "later-today-evening", "tomorrow-morning"]]],
+
+  "Regnskyll fram til senere på morgenen, som starter igjen i løpet av kvelden.":
+    ["sentence", ["until-starting-again",
+      "heavy-rain",
+      "later-today-morning",
+      "today-evening"]],
+
+  "Overskyet som starter om kvelden, fortsetter fram til om natten.":
+    ["sentence", ["starting-continuing-until",
+      "heavy-clouds",
+      "evening",
+      "night"]],
+
+  "Lett sludd senere på ettermiddagen og tåke i morgen tidlig.":
+    ["sentence", ["and",
+      ["during", "light-sleet", "later-today-afternoon"],
+      ["during", "fog", "tomorrow-morning"]]],
+
+  "Storm som starter i løpet av formiddagen, fortsetter fram til på ettermiddagen og sludd i morgen tidlig.":
+    ["sentence", ["and",
+      ["starting-continuing-until",
+        "heavy-wind",
+        "today-morning",
+        "today-afternoon"],
+      ["during", "medium-sleet", "tomorrow-morning"]]],
+
+  "Overskyet som starter senere i kveld og rikelig med snø i morgen ettermiddag.":
+    ["sentence", ["and",
+      ["starting", "heavy-clouds", "later-today-night"],
+      ["during", "heavy-snow", "tomorrow-afternoon"]]],
+
+  "Tørke i kveld og lett nedbør som starter i morgen kveld, fortsetter fram til i morgen natt.":
+    ["sentence", ["and",
+      ["during", "low-humidity", "today-night"],
+      ["starting-continuing-until",
+        "light-precipitation",
+        "tomorrow-evening",
+        "tomorrow-night"]]],
+
+  "Snø (5 in.) om natten.":
+    ["sentence", ["during",
+      ["parenthetical", "medium-snow", ["inches", 5]],
+      "night"]],
+
+  "Lett snø (2 cm.) senere på morgenen.":
+    ["sentence", ["during",
+      ["parenthetical", "light-snow", ["centimeters", 2]],
+      "later-today-morning"]],
+
+  "Rikelig med snø (8\u201312 in.) i løpet av dagen.":
+    ["sentence", ["for-day",
+      ["parenthetical", "heavy-snow", ["inches", ["range", 8, 12]]]]],
+
+  "Snø (under 1 cm.) på ettermiddagen.":
+    ["sentence", ["during",
+      ["parenthetical", "medium-snow", ["less-than", ["centimeters", 1]]],
+      "afternoon"]],
+
+  "Ingen målbar nedbør i løpet av uken, med temperaturer opptil 85\u00B0F i morgen.":
+    ["sentence", ["with",
+      ["for-week", "no-precipitation"],
+      ["temperatures-peaking",
+        ["fahrenheit", 85],
+        "tomorrow"]]],
+
+  "Blandet nedbør over helgen, med temperaturer som stiger til 32\u00B0C på torsdag.":
+    ["sentence", ["with",
+      ["over-weekend", "mixed-precipitation"],
+      ["temperatures-rising",
+        ["celsius", 32],
+        "thursday"]]],
+
+  "Duskregn på mandag, med temperaturer som stopper på 15\u00B0F på fredag.":
+    ["sentence", ["with",
+      ["during", "very-light-rain", "monday"],
+      ["temperatures-valleying",
+        ["fahrenheit", 15],
+        "friday"]]],
+
+  "Lett snø på tirsdag og onsdag, med temperaturer som synker til 0\u00B0C på søndag.":
+    ["sentence", ["with",
+      ["during", "light-snow", ["and", "tuesday", "wednesday"]],
+      ["temperatures-falling",
+        ["celsius", 0],
+        "sunday"]]],
+
+  "Nedbør i dag fram til på lørdag, med temperaturer opptil 100\u00B0F på mandag.":
+    ["sentence", ["with",
+      ["during",
+        "medium-precipitation",
+        ["through", "today", "saturday"]],
+      ["temperatures-peaking",
+        ["fahrenheit", 100],
+        "monday"]]]
+}


### PR DESCRIPTION
Based on the Swedish translations.

As Norway has two offical written languages (Bokmaal - `nb` and Nynorsk - `nn`), I have written the translations for Norwegian Bokmaal (`nb`) instead of just Norwegian (`no`) to keep the Bokmaal translations separate from Nynorsk - if that is okay with you :smile: .

> alni
