### PR TITLE
Dutch translation: "weinig wind" -> "lichte wind"

### DIFF
--- a/lib/lang/nl.js
+++ b/lib/lang/nl.js
@@ -48,7 +48,7 @@ module.exports = require("../template")({
   "light-snow": "sneeuwval",
   "medium-snow": "sneeuw",
   "heavy-snow": "zware sneeuwbuien",
-  "light-wind": "weinig wind",
+  "light-wind": "lichte wind",
   "medium-wind": "veel wind",
   "heavy-wind": "zware windstoten",
   "low-humidity": "lage luchtvochtigheid",

--- a/test_cases/nl.json
+++ b/test_cases/nl.json
@@ -68,7 +68,7 @@
   "Mogelijk lichte ijzel":
     ["title", "possible-light-sleet"],
 
-  "Lage luchtvochtigheid en weinig wind":
+  "Lage luchtvochtigheid en lichte wind":
     ["title", ["and", "low-humidity", "light-wind"]],
 
   "Hoge luchtvochtigheid en licht bewolkt":
@@ -110,7 +110,7 @@
   "Zware neerslag tot de middag.":
     ["sentence", ["until", "heavy-precipitation", "afternoon"]],
 
-  "Weinig wind gedurende de middag.":
+  "Lichte wind gedurende de middag.":
     ["sentence", ["during", "light-wind", "afternoon"]],
 
   "Sneeuw gedurende later vanavond en morgenochtend.":


### PR DESCRIPTION
In the Dutch translation, translate "light wind" as "lichte wind" instead of "weinig wind". This better corresponds to what is meant. "Weinig wind" means "not a lot of wind", implying that "no wind" is an option too.